### PR TITLE
Fix command parser

### DIFF
--- a/src/client/repl.rs
+++ b/src/client/repl.rs
@@ -52,7 +52,7 @@ fn read(editor: &mut Editor<()>) -> Result<Input, String> {
       editor.add_history_entry(line.as_ref());
       match command::parse(&line) {
         Ok(cmd) => Result::Ok(Input::Cmd(cmd)),
-        Err(msg) => Result::Err(msg),
+        Err(_) => Result::Err(String::from("Invalid command")),
       }
     }
     Err(ReadlineError::Interrupted) => Result::Ok(Input::Break),


### PR DESCRIPTION
This fixes the command parser to not accept garbage after a  valid command anymore.
This makes the implementation more robust and removes surprising behaviour. 

Before the change the following was valid, which is now invalid:

```
:insert foo bar somegarbage
```